### PR TITLE
Modify docker file to use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM  node:10-alpine
 MAINTAINER OhMyForm <admin@ohmyform.com>
 
-# Create a group and a user with name "ohmyformUser".
-RUN addgroup -g 9999 ohmyformGroup && adduser -u 99999 -D -g ohmyformGroup ohmyformUser
+# Create a group and a user with name "ohmyform".
+RUN addgroup --gid 9999 ohmyform && adduser -D --uid 9999 -G ohmyform ohmyform
 
 # Install some needed packages
 RUN apk add --no-cache git python \
@@ -52,7 +52,7 @@ RUN npm install --only=production \
     && grunt build
 
 # Change to non-root privilege
-USER ohmyformUser
+USER ohmyform
 
 # Run OhMyForm server
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM  node:10-alpine
 MAINTAINER OhMyForm <admin@ohmyform.com>
 
+# Create a group and a user with name "ohmyformUser".
+RUN addgroup -g 9999 ohmyformGroup && adduser -u 99999 -D -g ohmyformGroup ohmyformUser
+
 # Install some needed packages
 RUN apk add --no-cache git python \
 	&& rm -rf /tmp/* \
@@ -47,6 +50,9 @@ COPY . .
 RUN npm install --only=production \
     && bower install --allow-root -f \
     && grunt build
+
+# Change to non-root privilege
+USER ohmyformUser
 
 # Run OhMyForm server
 CMD ["node", "server.js"]


### PR DESCRIPTION
As requested in issue #43, this PR runs the application in a restricted user as opposed to the current run as root by default. 

**Changes:**
A new group and user with name `ohmyformUser` and id of `999` are created. Docker is then set to use this new user (non-root) in all of the operations.
