### PR TITLE
Remove grunt-contrib-uglify dependency. It's needed only as dev depen…

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "grunt-contrib-csslint": "^2.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
     "grunt-contrib-jshint": "^2.1.0",
-    "grunt-contrib-uglify": "^4.0.1",
     "grunt-env": "^0.4.4",
     "grunt-html2js": "^0.6.0",
     "grunt-ng-annotate": "^3.0.0",


### PR DESCRIPTION
…dency

grunt-contrib-uglify was as dependency and dev dependency

## Description
grunt-contrib-uglify was as dependency and dev-dependency

## Motivation and Context
docker build warns that grunt-contrib-uglify is twice in package.json. Project doesn't have grunt-contrib-uglify imported anywhere and it can be therefore as dev-dependency

