### PR TITLE
Add link to README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Moving over to Discord so that I can manage things without hassle.
 	- Embeddable Forms
 	- Forms as a Service API
 
-<!-- TODO: Determine roadmap for OhMyForm if it is to be different from OhMyForm's roadmap.
-### On the Roadmap (Tentative pending [refactor](https://github.com/ohmyform/ohmyform/pull/1))
+<!-- TODO: Determine roadmap for OhMyForm if it is to be different from OhMyForm's roadmap. -->
+<!-- ### On the Roadmap (Tentative pending [refactor](https://github.com/ohmyform/ohmyform/pull/1)) -->
+### On the Roadmap for v1.0.0
 	- Implement encryption for all form data
 	- Add Typeform API integration
 	- Add plugin/3rd party integration support (ala Slack)
@@ -56,13 +57,13 @@ Moving over to Discord so that I can manage things without hassle.
 	- Add Custom Background and Dropdown Field Images
 	- Add File Upload Form Field
 	- Deployable with Heroku and DockerHub
--->
 
 
-<!-- TODO: add a CONTRIBUTING.md.
+
+<!-- TODO: add a CONTRIBUTING.md. -->
 ## How to Contribute
 
-Please checkout our CONTRIBUTING.md on ways to contribute to OhMyForm. -->
+Please checkout our CONTRIBUTING.md on ways to contribute to OhMyForm.
 
 ## Quickstart
 


### PR DESCRIPTION
## Description
Added correct links to table of contents on README.
A CONTRIBUTING file is now required, as the README file says to checkout this file but it's not yet created.

## Motivation and Context
This fix aims to add and ease the access to the resources present on README.
Issue https://github.com/ohmyform/ohmyform/issues/47

## How Has This Been Tested?
After implementing, I've tested all links by clicking them and they properly scroll the page to the correspondent section of the README file.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

