### PR TITLE
bugfix hashPassword call that is made with null

### DIFF
--- a/app/models/user.server.model.js
+++ b/app/models/user.server.model.js
@@ -110,7 +110,7 @@ UserSchema.virtual('password').get(function () {
  * Create instance method for hashing a password
  */
 UserSchema.statics.hashPassword = UserSchema.methods.hashPassword = function(password) {
-  return bcrypt.hashSync(password, 4);
+  return password ? bcrypt.hashSync(password, 4) : false;
 };
 
 /**


### PR DESCRIPTION
during login hashpassword is called with null -> this causes the login to fail