### PR TITLE
Fix file logger creation

### DIFF
--- a/config/logger.js
+++ b/config/logger.js
@@ -49,7 +49,7 @@ logger.setupFileLogger = function setupFileLogger() {
     // Check first if the configured path is writable and only then
     // instantiate the file logging transport
     if (fs.openSync(fileLoggerTransport.filename, 'a+')) {
-      logger.add(new winston.transports.File(), fileLoggerTransport);
+      logger.add(new winston.transports.File(fileLoggerTransport));
     }
 
     return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The file logger is triggered only in production mode and does not works :
```An error has occured during the creation of the File transport logger.
Error: Cannot log to file without filename or stream.
```
Just a small fix, [according to Winston documentation](https://github.com/winstonjs/winston#creating-your-own-logger).

## How Has This Been Tested?
Rebuild docker image and re-launch Docker Compose with NODE_ENV=production. The error is gone.

The error is gone and the default logfile (`/opt/app/app.log`) is populated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

