### PR TITLE
Fix PaaS deployment via Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./node_modules/.bin/forever -m 5 server.js
+web: node server.js

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate": "all-contributors generate",
     "start": "grunt",
     "test": "grunt test",
-    "postinstall": "bower install --config.interactive=false",
+    "postinstall": "bower install --config.interactive=false && grunt build",
     "init": "node scripts/setup.js"
   },
   "dependencies": {


### PR DESCRIPTION
This patch fixes deployment into Platform as a Service environments which support a `Procfile`.

See discussion in #81 

This branch has been tested locally and with Heroku and works fine.
