### PR TITLE
Switched to non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ COPY --from=api /usr/src/app/out /usr/src/app/public
 
 RUN yarn install --frozen-lockfile
 RUN yarn build
+## Glue
+RUN addgroup --gid 9999 ohmyform && adduser --disabled-login --uid 9999 --gid 9999 ohmyform && \
+      touch /usr/src/app/src/schema.gql && chown ohmyform:ohmyform /usr/src/app/src/schema.gql
 
 ## Production Image.
 FROM node:12

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ COPY --from=api /usr/src/app/out /usr/src/app/public
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
+## Glue
+RUN touch /usr/src/app/src/schema.gql && chown ohmyform:ohmyform /usr/src/app/src/schema.gql
+
 ## Production Image.
 FROM node:12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as builder
+FROM node:12-alpine as builder
 
 WORKDIR /usr/src/app
 
@@ -7,8 +7,11 @@ COPY ui/ .
 RUN yarn install --frozen-lockfile
 RUN yarn export
 
-FROM node:12
+FROM node:12-alpine
 LABEL maintainer="OhMyForm <admin@ohmyform.com>"
+
+# Create a group and a user with name "ohmyform".
+RUN addgroup --gid 9999 ohmyform && adduser -D --uid 9999 -G ohmyform ohmyform
 
 WORKDIR /usr/src/app
 
@@ -26,5 +29,8 @@ ENV PORT=3000 \
     ADMIN_PASSWORD=root
 
 EXPOSE 3000
+
+# Change to non-root privilege
+USER ohmyform
 
 CMD [ "yarn", "start:prod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ COPY --from=api /usr/src/app/out /usr/src/app/public
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
-## Glue
-RUN touch /usr/src/app/src/schema.gql && chown ohmyform:ohmyform /usr/src/app/src/schema.gql
-
 ## Production Image.
 FROM node:12
 


### PR DESCRIPTION
## Description 
Re-implemented the non-root container operation previously completed in #43.  This required copying the adduser line plus USER directive line back into the dockerfile.

## Motivation and Context
This will ensure organisations that have policies preventing containers running as root user will be able to deploy and run Ohmyform.

## How Has This Been Tested?
- Completed local `docker build .` and local `docker-compose up -d`, both completed successfully.
- Navigated to the locally running application web interface, logged in and created a form.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

