### PR TITLE
Correct opencollective Sponsor link.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 # github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 # patreon: # Replace with a single Patreon username
-open_collective: ohmyform
+open_collective: ohmyform-sustainability
 # ko_fi: # Replace with a single Ko-fi username
 # tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 # community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
Hi! Thanks for the project!

Clicked the link on the side of the main repo page and went to the wrong place, but seems there's another place.

was: https://opencollective.com/ohmyform 
pr: https://opencollective.com/ohmyform-sustainability

OC team can probably move your namespace around if you'd like the `/ohmyform` namespace instead of `/ohmyform-sustainability`, and I'm happy to coordinate that if you'd like (I'm already in the Slack for other reasons)

If not, perhaps we should delete the unused OC collective page so it's not lingering around?