### PR TITLE
docker-compose: ohmyform actually listens on port 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - redis
       - mail
     ports:
-      - "5200:3000"
+      - "3000:3000"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Adjusts port mapping to account for the fact that the nginx server
running under supervisord takes care of redirecting the traffic,
and it listens on the port 3000.