### PR TITLE
Updated install link for node-prune

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /usr/src/api
 RUN apk --update --no-cache add curl bash g++ make libpng-dev
 
 # install node-prune (https://github.com/tj/node-prune)
-RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash -s -- -b /usr/local/bin
+RUN curl -sf https://gobinaries.com/tj/node-prune | sh
 
 COPY api/ .
 


### PR DESCRIPTION
Updated node-prune install script link to resolve docker-compose build failure.

## Description
Updated the script install link for node-prune from https://install.goreleaser.com/github.com/tj/node-prune.sh (which is getting a server not found) to https://gobinaries.com/tj/node-prune. Also changed the command to the one found on the Readme file: https://github.com/tj/node-prune/blob/master/Readme.md#installation.
Due to the script not being downloaded, ```docker-compose up -d``` command would fail at Step 19, with the following message:
```
Step 19/32 : RUN /usr/local/bin/node-prune
 ---> Running in 4f975151ee9b
/bin/sh: /usr/local/bin/node-prune: not found
The command '/bin/sh -c /usr/local/bin/node-prune' returned a non-zero code: 127
````

## Motivation and Context
This change allows ```docker-compose up -d``` to finish successfully. 

## How Has This Been Tested?
Ran ```docker-compose up -d```. The build successfully completed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

