### PR TITLE
Preview Environments for PRs opened on ohmyform

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,153 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+  build-ohmyform-ui:
+    name: Build and push `OhMyForm UI`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download submodules
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+          ls
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push the Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./ui
+          file: ./ui/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  build-ohmyform-api:
+    name: Build and push `OhMyForm API`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Download submodules
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+          ls
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push the Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-ohmyform-ui
+      - build-ohmyform-api
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          OHMYFORM_UI_IMAGE=${{ needs.build-ohmyform-ui.outputs.tags }}
+          export OHMYFORM_UI_IMAGE
+          OHMYFORM_API_IMAGE=${{ needs.build-ohmyform-api.outputs.tags }}
+          export OHMYFORM_API_IMAGE
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,86 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,61 @@
+version: '3'
+
+# uffizzi integration
+x-uffizzi:
+  ingress:
+    service: nginx
+    port: 8081
+
+services:
+
+  redis:
+    image: redis
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx-uffizzi:/etc/nginx
+
+  db:
+    image: postgres
+    volumes:
+      - pg_data:/var/lib/postgresql
+    ports:
+        - "5432:5432"
+    deploy:
+            resources:
+              limits:
+                memory: 500M
+    environment:
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_DB=ohmyform
+
+  ui:
+    image: "${OHMYFORM_UI_IMAGE}"
+    entrypoint: /bin/sh
+    command:
+         - "-c"
+         - "ENDPOINT=$$UFFIZZI_URL/graphql SERVER_ENDPOINT=$$UFFIZZI_URL/graphql yarn start"
+    deploy:
+      resources:
+        limits:
+          memory: 250M
+
+  api:
+    image: "${OHMYFORM_API_IMAGE}"
+    environment:
+      - CREATE_ADMIN=true
+      - ADMIN_EMAIL=admin@admin.com
+      - ADMIN_USERNAME=admin
+      - ADMIN_PASSWORD=admin
+      - DATABASE_DRIVER=postgres
+      - DATABASE_URL=postgresql://root:root@localhost:5432/ohmyform
+      - REDIS_URL=redis://localhost:6379
+    deploy:
+      resources:
+        limits:
+          memory: 1000M
+
+volumes:
+   pg_data:

--- a/nginx-uffizzi/nginx.conf
+++ b/nginx-uffizzi/nginx.conf
@@ -1,0 +1,54 @@
+user nginx;
+worker_processes  1;
+error_log /dev/stderr debug;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024; #default
+}
+
+http{
+
+      log_format json_combined escape=json
+                 '{'
+                   '"time_local":"$time_local",'
+                   '"remote_addr":"$remote_addr",'
+                   '"remote_user":"$remote_user",'
+                   '"request":"$request",'
+                   '"status": "$status",'
+                   '"body_bytes_sent":"$body_bytes_sent",'
+                   '"request_time":"$request_time",'
+                   '"http_referrer":"$http_referer",'
+                   '"http_user_agent":"$http_user_agent"'
+                 '}';
+
+    access_log /var/log/nginx/access.log json_combined;
+  server {
+    listen 8081;
+
+    location / {
+          proxy_pass         http://localhost:4000;
+          proxy_redirect     off;
+          proxy_set_header   Host $host;
+
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /graphql {
+          proxy_pass         http://localhost:3000;
+          proxy_redirect     off;
+          proxy_set_header   Host $host;
+
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+
+          # WebSocket support
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+    }
+}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is adding support for preview environments for PR events (opened, sync'ed, reopneded, etc), powered by [Uffizzi](https://www.uffizzi.com/). This PR is using GHA workflows to build and provision the preview environments. Utilizing docker-compose examples from ohmyform, the PR builds `ohmyform-ui` and `ohmyform-api` from source - this makes sure the latest changes are reflected in the preview. The docker-compose also includes a Redis instance, a Postgres instant, and Nginx for routing. 

Once a PR event is triggered — _PR opened, PR synced, review requested_ — the build workflow will build the images and the preview workflows will either spin up a new preview or update an existing preview. A comment will be posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Fixes - https://github.com/ohmyform/ohmyform/issues/203

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to allow maintainers and contributors to approve contributions in half the time with live previews for every pull request. To test branches in isolation and merge with confidence. Testing changes for services with multiple components can be cumbersome - polluted environments, merge conflicts, and build every time the change needs to be tested and approved. The idea behind preview environments by Uffizzi is to eliminate these frictions while testing and approving changes. An in-depth study on preview environments can be found [here](https://www.uffizzi.com/preview-environments-guide). 

With this PR, changes to `ohmyform-ui` and `ohmyform-api` will spin up a production-like ephemeral preview environment. The environment can be used for testing the FE and the BE aspect of `ohmyform` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In order to test this, I have created a [PR](https://github.com/ShrutiC-git/ohmyform/pull/7) against the main branch of my personal fork of `ohmyform`. This triggered the workflow to create a new preview environment - [here](https://pr-7-deployment-8734-ohmyform.app.uffizzi.com/). This [comment](https://github.com/ShrutiC-git/ohmyform/pull/7#issuecomment-1343898660), posted on the PR, takes me to the preview environment.

To log into the above preview environment, use the following credentials:
- username: admin
- password: admin

Once you are logged in, you will be able to do all you would on a production instance of OhMyForm; create forms, share forms, track submissions, etc. Changes made to the FE and BE will reflect on the preview environment. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

cc @wodka @waveywaves