### PR TITLE
make nginx listen on ipv4 and ipv6

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,7 +24,7 @@ http {
     access_log /var/log/nginx/access.log json_combined;
 
     server {
-        listen 3000;
+        listen [::]:3000 ipv6only=off;
 
         location / {
           proxy_pass         http://localhost:4000;


### PR DESCRIPTION
we don't support legacy IP for free tier at kraud.cloud.  would be nice to get ohmyform working by default

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

